### PR TITLE
feat(*) lazy-load API objects

### DIFF
--- a/src/resty/gcp/init.lua
+++ b/src/resty/gcp/init.lua
@@ -99,7 +99,8 @@ end
 
 local load_api
 do
-    local cache = {}
+    -- using weak values so that API objects can be garbage-collected
+    local cache = setmetatable({}, { __mode = "v" })
 
     function load_api(service)
         if not APIS[service] then


### PR DESCRIPTION
This changeset greatly reduces the startup cost for `lua-resty-gcp`.

## changelog

* lazy-load API objects
* memoize API object generation

## benchmark

```lua
ngx.update_time()
local start = ngx.now()

collectgarbage()
print("before require: ", collectgarbage("count"))

local GCP = require "resty.gcp"
print("after require: ", collectgarbage("count"))

local gcp = GCP()
print("after initializing: ", collectgarbage("count"))

assert(gcp.secretmanager_v1 ~= nil)
assert(gcp.compute_v1 ~= nil)
assert(gcp.apigee_v1 ~= nil)
assert(gcp.healthcare_v1 ~= nil)
print("after loading a few APIs: ", collectgarbage("count"))

local other = GCP()
print("after creating another instance: ", collectgarbage("count"))

assert(other.secretmanager_v1 ~= nil)
assert(other.compute_v1 ~= nil)
assert(other.apigee_v1 ~= nil)
assert(other.healthcare_v1 ~= nil)
print("api objects are shared: ", gcp.secretmanager_v1 == other.secretmanager_v1)
print("after loading APIS on the new instance: ", collectgarbage("count"))

gcp = nil
other = nil
collectgarbage("collect")
print("after garbage collection: ", collectgarbage("count"))

ngx.update_time()
print("duration: ", ngx.now() - start)
```


## main
```
$ resty -I src bench.lua  | column -t -s :
before require                           193.83203125
after require                            351.228515625
after initializing                       78745.106445313
after loading a few APIs                 78745.375976563
after creating another instance          80830.696289063
api objects are shared                   false
after loading APIS on the new instance   80831.208007813
after garbage collection                 69850.428710938
duration                                 0.5460000038147
```

## feat/lazy-load-apis
```
$ resty -I src bench.lua  | column -t -s :
before require                           193.83203125
after require                            353.4892578125
after initializing                       868.9765625
after loading a few APIs                 9576.9921875
after creating another instance          9577.328125
api objects are shared                   true
after loading APIS on the new instance   9577.92578125
after garbage collection                 5299.8740234375
duration                                 0.029999971389771
```