### PR TITLE
feat(access_token): make access token refresh automatically

### DIFF
--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -2,37 +2,46 @@ local restore = require "spec.helpers"
 
 describe("access token", function ()
   local access_token
+  
+  -- true for real GCP, false for mock
+  local USE_REAL_GCP = false
+  
   setup(function()
-    local http = {
-      new = function()
-        return {
-          counter = 0,
-          close = function() return true end,
-          request_uri = function(self, url, opts)
-            self.counter = self.counter + 1
-            if url == "https://www.googleapis.com/oauth2/v4/token" then
-              return {
-                status = 200,
-                body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
-              }
-            elseif url == "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" then
-              return {
-                status = 200,
-                body = [[{"access_token": "test_wi", "expires_in": 3600}]],
-              }
-            else
-              error("bad test path provided??? " .. tostring(opts.path))
-            end
-          end,
-        }
-      end,
-    }
 
-    package.loaded["resty.luasocket.http"] = http
+    if not USE_REAL_GCP then
+      local http = {
+        new = function()
+          return {
+            counter = 0,
+            close = function() return true end,
+            request_uri = function(self, url, opts)
+              self.counter = self.counter + 1
+              if url == "https://www.googleapis.com/oauth2/v4/token" then
+                return {
+                  status = 200,
+                  body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
+                }
+              elseif url == "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" then
+                return {
+                  status = 200,
+                  body = [[{"access_token": "test_wi", "expires_in": 3600}]],
+                }
+              else
+                error("bad test path provided??? " .. tostring(opts.path))
+              end
+            end,
+          }
+        end,
+      }
+
+      package.loaded["resty.luasocket.http"] = http
+    end
   end)
 
   teardown(function()
-    package.loaded["resty.luasocket.http"] = nil
+    if not USE_REAL_GCP then
+      package.loaded["resty.luasocket.http"] = nil
+    end
   end)
 
   before_each(function()
@@ -55,22 +64,144 @@ describe("access token", function ()
 
   it("should create an access token with default auth method", function()
     local gcpToken = access_token()
-    assert.same(gcpToken.token, "test_wi")
+    
+    if USE_REAL_GCP then
+      assert.is_string(gcpToken.token)
+      assert.is_not_nil(gcpToken.token)
+      assert.is_true(#gcpToken.token > 0)
+    else
+      assert.same(gcpToken.token, "test_wi")
+    end
+    
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
 
   it("should create an access token with legacy auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "legacy" })
-    assert.same(gcpToken.token, "test_wi")
+    
+    if USE_REAL_GCP then
+      assert.is_string(gcpToken.token)
+      assert.is_not_nil(gcpToken.token)
+      assert.is_true(#gcpToken.token > 0)
+    else
+      assert.same(gcpToken.token, "test_wi")
+    end
+    
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
 
   it("should create an access token with adc auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "adc" })
-    assert.same(gcpToken.token, "test_jwt")
+    
+    if USE_REAL_GCP then
+      assert.is_string(gcpToken.token)
+      assert.is_not_nil(gcpToken.token)
+      assert.is_true(#gcpToken.token > 0)
+    else
+      assert.same(gcpToken.token, "test_jwt")
+    end
+    
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
+
+  it("should handle access token error with invalid credentials", function()
+    -- use invalid Service Account JSON
+    local invalidAccount = '{"invalid": "json"}'
+    
+    if USE_REAL_GCP then
+      local ok, result = pcall(access_token, invalidAccount)
+      if ok then
+        assert.is_not_nil(result)
+        assert.same(invalidAccount, result.gcpServiceAccount)
+      else
+        assert.is_string(result)
+        assert.is_true(#result > 0)
+      end
+    else
+      local invalidToken = access_token(invalidAccount)
+      assert.is_not_nil(invalidToken)
+      assert.same(invalidAccount, invalidToken.gcpServiceAccount)
+      assert.is_string(invalidToken.token)
+    end
+  end)
+
+  it("should handle an expired wi access token to refresh", function()
+      -- test WI refresh
+      local wiToken = access_token(nil, {
+          auth_method_order = "legacy"
+      })
+
+      assert.same("string", type(wiToken.token))
+      assert.same("number", type(wiToken.expireTime))
+      assert.same("WI", wiToken.authMethod)
+      assert.is_false(wiToken:needsRefresh())
+
+      wiToken.expireTime = ngx.now() - 100
+      assert.is_true(wiToken:needsRefresh())
+
+      local ok, result = wiToken:get()
+
+      assert.is_true(ok)
+      assert.equals(wiToken, result)
+      assert.same("string", type(wiToken.token))
+      assert.same("number", type(wiToken.expireTime))
+      assert.same("WI", wiToken.authMethod)
+      assert.is_false(wiToken:needsRefresh())
+
+  end)
+
+  it("should handle an expired sa access token to refresh", function()
+      -- test ADC refresh
+      local saToken = access_token(nil, {
+          auth_method_order = "adc"
+      })
+
+      assert.same("string", type(saToken.token))
+      assert.same("number", type(saToken.expireTime))
+      assert.same("SA", saToken.authMethod)
+      assert.is_false(saToken:needsRefresh())
+
+      saToken.expireTime = ngx.now() - 100
+      assert.is_true(saToken:needsRefresh())
+
+      local ok, result = saToken:get()
+
+      assert.is_true(ok)
+      assert.equals(saToken, result)
+      assert.same("string", type(saToken.token))
+      assert.same("number", type(saToken.expireTime))
+      assert.same("SA", saToken.authMethod)
+      assert.is_false(wiToken:needsRefresh())
+  end)
+
+  it("should handle AccessToken:get() concurrency simulation", function()
+    local gcpToken = access_token()
+    
+    gcpToken.expireTime = ngx.now() - 100
+    
+    local results = {}
+    local errors = {}
+    
+    for i = 1, 3 do
+        local ok, result = gcpToken:get()
+        if ok then
+            table.insert(results, result)
+        else
+            table.insert(errors, result)
+        end
+    end
+    
+    assert.equals(3, #results)
+    assert.equals(0, #errors)
+    
+    for i = 1, #results do
+        assert.equals(gcpToken, results[i])
+    end
+    
+    assert.is_false(gcpToken:needsRefresh())
+  end)
+
 end)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -3,45 +3,39 @@ local restore = require "spec.helpers"
 describe("access token", function ()
   local access_token
   
-  -- true for real GCP, false for mock
-  local USE_REAL_GCP = false
-  
   setup(function()
 
-    if not USE_REAL_GCP then
-      local http = {
-        new = function()
-          return {
-            counter = 0,
-            close = function() return true end,
-            request_uri = function(self, url, opts)
-              self.counter = self.counter + 1
-              if url == "https://www.googleapis.com/oauth2/v4/token" then
-                return {
-                  status = 200,
-                  body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
-                }
-              elseif url == "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" then
-                return {
-                  status = 200,
-                  body = [[{"access_token": "test_wi", "expires_in": 3600}]],
-                }
-              else
-                error("bad test path provided??? " .. tostring(opts.path))
-              end
-            end,
-          }
-        end,
-      }
+    local http = {
+      new = function()
+        return {
+          counter = 0,
+          close = function() return true end,
+          request_uri = function(self, url, opts)
+            self.counter = self.counter + 1
+            if url == "https://www.googleapis.com/oauth2/v4/token" then
+              return {
+                status = 200,
+                body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
+              }
+            elseif url == "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" then
+              return {
+                status = 200,
+                body = [[{"access_token": "test_wi", "expires_in": 3600}]],
+              }
+            else
+              error("bad test path provided??? " .. tostring(opts.path))
+            end
+          end,
+        }
+      end,
+    }
 
-      package.loaded["resty.luasocket.http"] = http
-    end
+    package.loaded["resty.luasocket.http"] = http
+    
   end)
 
   teardown(function()
-    if not USE_REAL_GCP then
-      package.loaded["resty.luasocket.http"] = nil
-    end
+    package.loaded["resty.luasocket.http"] = nil
   end)
 
   before_each(function()
@@ -65,14 +59,7 @@ describe("access token", function ()
   it("should create an access token with default auth method", function()
     local gcpToken = access_token()
     
-    if USE_REAL_GCP then
-      assert.is_string(gcpToken.token)
-      assert.is_not_nil(gcpToken.token)
-      assert.is_true(#gcpToken.token > 0)
-    else
-      assert.same(gcpToken.token, "test_wi")
-    end
-    
+    assert.same(gcpToken.token, "test_wi")
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
@@ -80,14 +67,7 @@ describe("access token", function ()
   it("should create an access token with legacy auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "legacy" })
     
-    if USE_REAL_GCP then
-      assert.is_string(gcpToken.token)
-      assert.is_not_nil(gcpToken.token)
-      assert.is_true(#gcpToken.token > 0)
-    else
-      assert.same(gcpToken.token, "test_wi")
-    end
-    
+    assert.same(gcpToken.token, "test_wi")    
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
@@ -95,14 +75,7 @@ describe("access token", function ()
   it("should create an access token with adc auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "adc" })
     
-    if USE_REAL_GCP then
-      assert.is_string(gcpToken.token)
-      assert.is_not_nil(gcpToken.token)
-      assert.is_true(#gcpToken.token > 0)
-    else
-      assert.same(gcpToken.token, "test_jwt")
-    end
-    
+    assert.same(gcpToken.token, "test_jwt")
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
@@ -110,22 +83,10 @@ describe("access token", function ()
   it("should handle access token error with invalid credentials", function()
     -- use invalid Service Account JSON
     local invalidAccount = '{"invalid": "json"}'
-    
-    if USE_REAL_GCP then
-      local ok, result = pcall(access_token, invalidAccount)
-      if ok then
-        assert.is_not_nil(result)
-        assert.same(invalidAccount, result.gcpServiceAccount)
-      else
-        assert.is_string(result)
-        assert.is_true(#result > 0)
-      end
-    else
       local invalidToken = access_token(invalidAccount)
       assert.is_not_nil(invalidToken)
       assert.same(invalidAccount, invalidToken.gcpServiceAccount)
       assert.is_string(invalidToken.token)
-    end
   end)
 
   it("should handle an expired wi access token to refresh", function()
@@ -142,10 +103,6 @@ describe("access token", function ()
       wiToken.expireTime = ngx.now() - 100
       assert.is_true(wiToken:needsRefresh())
 
-      local ok, result = wiToken:get()
-
-      assert.is_true(ok)
-      assert.equals(wiToken, result)
       assert.same("string", type(wiToken.token))
       assert.same("number", type(wiToken.expireTime))
       assert.same("WI", wiToken.authMethod)
@@ -167,38 +124,36 @@ describe("access token", function ()
       saToken.expireTime = ngx.now() - 100
       assert.is_true(saToken:needsRefresh())
 
-      local ok, result = saToken:get()
 
-      assert.is_true(ok)
-      assert.equals(saToken, result)
       assert.same("string", type(saToken.token))
       assert.same("number", type(saToken.expireTime))
       assert.same("SA", saToken.authMethod)
       assert.is_false(saToken:needsRefresh())
   end)
 
-  it("should handle AccessToken:get() concurrency simulation", function()
+  it("should handle AccessToken refresh concurrency simulation", function()
     local gcpToken = access_token()
     
     gcpToken.expireTime = ngx.now() - 100
     
-    local results = {}
+    local tokens = {}
     local errors = {}
     
     for i = 1, 3 do
-        local ok, result = gcpToken:get()
-        if ok then
-            table.insert(results, result)
+        -- 直接访问 token 属性，会自动刷新
+        local token = gcpToken.token
+        if token then
+            table.insert(tokens, token)
         else
-            table.insert(errors, result)
+            table.insert(errors, "failed to get token")
         end
     end
     
-    assert.equals(3, #results)
+    assert.equals(3, #tokens)
     assert.equals(0, #errors)
     
-    for i = 1, #results do
-        assert.equals(gcpToken, results[i])
+    for i = 1, #tokens do
+        assert.equals(tokens[1], tokens[i])
     end
     
     assert.is_false(gcpToken:needsRefresh())

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -140,7 +140,6 @@ describe("access token", function ()
     local errors = {}
     
     for i = 1, 3 do
-        -- 直接访问 token 属性，会自动刷新
         local token = gcpToken.token
         if token then
             table.insert(tokens, token)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -174,7 +174,7 @@ describe("access token", function ()
       assert.same("string", type(saToken.token))
       assert.same("number", type(saToken.expireTime))
       assert.same("SA", saToken.authMethod)
-      assert.is_false(wiToken:needsRefresh())
+      assert.is_false(saToken:needsRefresh())
   end)
 
   it("should handle AccessToken:get() concurrency simulation", function()

--- a/src/resty/gcp/init.lua
+++ b/src/resty/gcp/init.lua
@@ -71,6 +71,10 @@ local function build_request(accesstoken, apiDetail, baseUrl, params, requestBod
         requestBody = cjson.encode(requestBody)
     end
 
+    if accesstoken.token == nil or #accesstoken.token == 0 then
+        error("Invalid access token")
+    end
+
     local req = {
         method = apiDetail.httpMethod,
         headers = {

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -204,11 +204,11 @@ function AccessToken:refresh()
             end
             self._semaphore = sema
 
-            local accessToken
+            local accessToken, err
             if (self.authMethod == "SA") then
-                accessToken = GetAccessTokenBySA(self.gcpServiceAccount)
+                accessToken, err = safe_call(GetAccessTokenBySA, self.gcpServiceAccount)
             elseif (self.authMethod == "WI") then
-                accessToken = GetAccessTokenByWI()
+                accessToken, err = safe_call(GetAccessTokenByWI)
             end
             
             if (accessToken) then
@@ -220,8 +220,8 @@ function AccessToken:refresh()
             sema:post(sema:count() + 1)
             
             if not accessToken then
-                ngx.log(ngx.ERR, "[accesstoken] failed to get new access token")
-                return nil, "failed to get new access token"
+                ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(err))
+                return nil, "failed to get new access token: " .. tostring(err)
             end
         end
     end

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -124,7 +124,7 @@ local AccessToken = {}
 function AccessToken.__index(self, key)
     if key == "token" then
         if self:needsRefresh() then
-            local ok, err = self:_auto_refresh()
+            local ok, err = self:refresh()
             if not ok then
                 ngx.log(ngx.ERR, "[accesstoken] auto refresh failed: ", tostring(err))
                 return nil
@@ -189,22 +189,6 @@ function AccessToken:needsRefresh()
 end
 
 function AccessToken:refresh()
-    local accessToken
-    if (self.authMethod == "SA") then
-        accessToken = GetAccessTokenBySA(self.gcpServiceAccount)
-    elseif (self.authMethod == "WI") then
-        accessToken = GetAccessTokenByWI()
-    end
-    if (accessToken) then
-        self._token = accessToken.access_token
-        self.expireTime = ngx.now() + accessToken.expires_in
-        return true
-    end
-    return false
-end
-
-
-function AccessToken:_auto_refresh()
     while self:needsRefresh() do
         if self._semaphore then
             local ok, err = self._semaphore:wait(SEMAPHORE_TIMEOUT)
@@ -212,7 +196,6 @@ function AccessToken:_auto_refresh()
                 ngx.log(ngx.ERR, "[accesstoken] semaphore wait failed: ", tostring(err))
                 return nil, "semaphore wait failed: " .. tostring(err)
             end
-
         else
             local sema, err = semaphore:new()
             if not sema then
@@ -221,18 +204,29 @@ function AccessToken:_auto_refresh()
             end
             self._semaphore = sema
 
-            local ok, err = safe_call(self.refresh, self)
+            local accessToken
+            if (self.authMethod == "SA") then
+                accessToken = GetAccessTokenBySA(self.gcpServiceAccount)
+            elseif (self.authMethod == "WI") then
+                accessToken = GetAccessTokenByWI()
+            end
+            
+            if (accessToken) then
+                self._token = accessToken.access_token
+                self.expireTime = ngx.now() + accessToken.expires_in
+            end
+
             self._semaphore = nil
             sema:post(sema:count() + 1)
             
-            if not ok then
-                ngx.log(ngx.ERR, "[accesstoken] refresh access token failed: ", tostring(err))
-                return nil, "refresh access token failed: " .. tostring(err)
+            if not accessToken then
+                ngx.log(ngx.ERR, "[accesstoken] failed to get new access token")
+                return nil, "failed to get new access token"
             end
         end
-
     end
-    return true, self
+
+    return true
 end
 
 return setmetatable(

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -120,7 +120,22 @@ local function GetAccessTokenByWI()
 end
 
 local AccessToken = {}
-AccessToken.__index = AccessToken
+
+function AccessToken.__index(self, key)
+    if key == "token" then
+        if self:needsRefresh() then
+            local ok, err = self:_auto_refresh()
+            if not ok then
+                ngx.log(ngx.ERR, "[accesstoken] auto refresh failed: ", tostring(err))
+                return nil
+            end
+        end
+        return rawget(self, "_token")
+    end
+    
+    return AccessToken[key]
+end
+
 function AccessToken:new(gcpServiceAccount, opts)
     local self = {}
     opts = opts or {}
@@ -155,7 +170,7 @@ function AccessToken:new(gcpServiceAccount, opts)
     end
 
     if (accessToken) then
-        self.token = accessToken.access_token
+        self._token = accessToken.access_token
         self.expireTime = ngx.now() + accessToken.expires_in
         self.authMethod = authMethod
         self.gcpServiceAccount = gcpServiceAccount
@@ -181,17 +196,18 @@ function AccessToken:refresh()
         accessToken = GetAccessTokenByWI()
     end
     if (accessToken) then
-        self.token = accessToken.access_token
+        self._token = accessToken.access_token
         self.expireTime = ngx.now() + accessToken.expires_in
         return true
     end
     return false
 end
 
-function AccessToken:get()
+
+function AccessToken:_auto_refresh()
     while self:needsRefresh() do
-        if self.semaphore then
-            local ok, err = self.semaphore:wait(SEMAPHORE_TIMEOUT)
+        if self._semaphore then
+            local ok, err = self._semaphore:wait(SEMAPHORE_TIMEOUT)
             if not ok then
                 ngx.log(ngx.ERR, "[accesstoken] semaphore wait failed: ", tostring(err))
                 return nil, "semaphore wait failed: " .. tostring(err)
@@ -203,10 +219,10 @@ function AccessToken:get()
                 ngx.log(ngx.ERR, "[accesstoken] create semaphore failed: ", tostring(err))
                 return nil, "create semaphore failed: " .. tostring(err)
             end
-            self.semaphore = sema
+            self._semaphore = sema
 
             local ok, err = safe_call(self.refresh, self)
-            self.semaphore = nil
+            self._semaphore = nil
             sema:post(sema:count() + 1)
             
             if not ok then
@@ -218,7 +234,6 @@ function AccessToken:get()
     end
     return true, self
 end
-
 
 return setmetatable(
     AccessToken,

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -1,6 +1,22 @@
 local http = require "resty.luasocket.http"
 local jwt = require "resty.jwt"
 local cjson = require("cjson.safe").new()
+local semaphore = require "ngx.semaphore"
+
+local SEMAPHORE_TIMEOUT = 30 -- semaphore timeout in seconds
+local EXPIRY_WINDOW = 15 -- expiry window in seconds
+
+-- Executes a xpcall but returns hard-errors as Lua 'nil+err' result.
+-- Handles max of 10 return values.
+-- @param f function to execute
+-- @param ... parameters to pass to the function
+local function safe_call(f, ...)
+  local ok, result, err, r3, r4, r5, r6, r7, r8, r9, r10 = xpcall(f, debug.traceback, ...)
+  if ok then
+    return result, err, r3, r4, r5, r6, r7, r8, r9, r10
+  end
+  return nil, result
+end
 
 local function GetJwtToken(serviceAccount)
     local saDecode, err = cjson.decode(serviceAccount)
@@ -142,23 +158,25 @@ function AccessToken:new(gcpServiceAccount, opts)
         self.token = accessToken.access_token
         self.expireTime = ngx.now() + accessToken.expires_in
         self.authMethod = authMethod
+        self.gcpServiceAccount = gcpServiceAccount
     else
         ngx.log(ngx.ERR, "[accesstoken] Unable to get accesstoken")
         error("Failed to authenticate")
         return nil
     end
+
+    self.expireWindow = opts.expireWindow or EXPIRY_WINDOW
     return self
 end
 
 function AccessToken:needsRefresh()
-    return self.expireTime < ngx.now()
+    return self.expireTime < (ngx.now() + self.expireWindow)
 end
 
 function AccessToken:refresh()
     local accessToken
     if (self.authMethod == "SA") then
-        local gcpServiceAccount = os.getenv("GCP_SERVICE_ACCOUNT")
-        accessToken = GetAccessTokenBySA(gcpServiceAccount)
+        accessToken = GetAccessTokenBySA(self.gcpServiceAccount)
     elseif (self.authMethod == "WI") then
         accessToken = GetAccessTokenByWI()
     end
@@ -169,6 +187,38 @@ function AccessToken:refresh()
     end
     return false
 end
+
+function AccessToken:get()
+    while self:needsRefresh() do
+        if self.semaphore then
+            local ok, err = self.semaphore:wait(SEMAPHORE_TIMEOUT)
+            if not ok then
+                ngx.log(ngx.ERR, "[accesstoken] semaphore wait failed: ", tostring(err))
+                return nil, "semaphore wait failed: " .. tostring(err)
+            end
+
+        else
+            local sema, err = semaphore:new()
+            if not sema then
+                ngx.log(ngx.ERR, "[accesstoken] create semaphore failed: ", tostring(err))
+                return nil, "create semaphore failed: " .. tostring(err)
+            end
+            self.semaphore = sema
+
+            local ok, err = safe_call(self.refresh, self)
+            self.semaphore = nil
+            sema:post(sema:count() + 1)
+            
+            if not ok then
+                ngx.log(ngx.ERR, "[accesstoken] refresh access token failed: ", tostring(err))
+                return nil, "refresh access token failed: " .. tostring(err)
+            end
+        end
+
+    end
+    return true, self
+end
+
 
 return setmetatable(
     AccessToken,

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -217,7 +217,7 @@ function AccessToken:refresh()
             end
 
             self._semaphore = nil
-            sema:post(sema:count() + 1)
+            sema:post(math.abs(sema:count()) + 1)
             
             if not accessToken then
                 ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(err))


### PR DESCRIPTION
### Summary
Make access token automatically refresh before it expires. Add unit tests for real gcp enviroment and the automatic token refresh feature.

### Issue reference
[FTI-6912](https://konghq.atlassian.net/browse/FTI-6912)

[FTI-6912]: https://konghq.atlassian.net/browse/FTI-6912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ