### PR TITLE
fix(access_token): fix AccessToken:new error and GetAccessTokenByWI handle get token failure.

### DIFF
--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -2,36 +2,66 @@ local restore = require "spec.helpers"
 
 describe("access token", function ()
   local access_token
-  
-  setup(function()
 
-    local http = {
+  -- Helper function to create HTTP mock with custom responses
+  local function create_http_mock(responses)
+    return {
       new = function()
         return {
           counter = 0,
           close = function() return true end,
           request_uri = function(self, url, opts)
             self.counter = self.counter + 1
-            if url == "https://www.googleapis.com/oauth2/v4/token" then
-              return {
-                status = 200,
-                body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
-              }
-            elseif url == "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" then
-              return {
-                status = 200,
-                body = [[{"access_token": "test_wi", "expires_in": 3600}]],
-              }
+            local response = responses[url]
+            if response then
+              if type(response) == "function" then
+                return response()
+              else
+                return response
+              end
             else
-              error("bad test path provided??? " .. tostring(opts.path))
+              error("bad test path provided??? " .. tostring(url))
             end
           end,
         }
       end,
     }
+  end
 
-    package.loaded["resty.luasocket.http"] = http
+  -- Helper function to temporarily replace HTTP mock
+  local function with_http_mock(mock_responses, test_function)
+    local original_http = package.loaded["resty.luasocket.http"]
+    package.loaded["resty.luasocket.http"] = create_http_mock(mock_responses)
     
+    -- Reload the access_token module to use the new HTTP mock
+    package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
+    local temp_access_token = require "resty.gcp.request.credentials.accesstoken"
+    
+    local success, result = pcall(test_function, temp_access_token)
+    
+    package.loaded["resty.luasocket.http"] = original_http
+    package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
+    
+    if not success then
+      error(result)
+    end
+    return result
+  end
+
+  -- Default successful responses
+  local default_responses = {
+    ["https://www.googleapis.com/oauth2/v4/token"] = {
+      status = 200,
+      body = [[{"access_token": "test_jwt", "expires_in": 3600}]],
+    },
+    ["http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"] = {
+      status = 200,
+      body = [[{"access_token": "test_wi", "expires_in": 3600}]],
+    }
+  }
+  
+  setup(function()
+    package.loaded["resty.luasocket.http"] = create_http_mock(default_responses)
   end)
 
   teardown(function()
@@ -58,7 +88,6 @@ describe("access token", function ()
 
   it("should create an access token with default auth method", function()
     local gcpToken = access_token()
-    
     assert.same(gcpToken.token, "test_wi")
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
@@ -66,7 +95,6 @@ describe("access token", function ()
 
   it("should create an access token with legacy auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "legacy" })
-    
     assert.same(gcpToken.token, "test_wi")    
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
@@ -74,19 +102,9 @@ describe("access token", function ()
 
   it("should create an access token with adc auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "adc" })
-    
     assert.same(gcpToken.token, "test_jwt")
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
-  end)
-
-  it("should handle access token error with invalid credentials", function()
-    -- use invalid Service Account JSON
-    local invalidAccount = '{"invalid": "json"}'
-      local invalidToken = access_token(invalidAccount)
-      assert.is_not_nil(invalidToken)
-      assert.same(invalidAccount, invalidToken.gcpServiceAccount)
-      assert.is_string(invalidToken.token)
   end)
 
   it("should handle an expired wi access token to refresh", function()
@@ -156,6 +174,49 @@ describe("access token", function ()
     end
     
     assert.is_false(gcpToken:needsRefresh())
+  end)
+
+  it("should fallback to WI when SA fails in ADC mode", function()
+    local sa_failure_responses = {
+      ["https://www.googleapis.com/oauth2/v4/token"] = {
+        status = 400,
+        body = [[{"error": "invalid_grant", "error_description": "Invalid JWT"}]],
+      },
+      ["http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"] = {
+        status = 200,
+        body = [[{"access_token": "test_wi_fallback", "expires_in": 3600}]],
+      }
+    }
+
+    with_http_mock(sa_failure_responses, function(temp_access_token)
+      local gcpToken = temp_access_token(nil, { auth_method_order = "adc" })
+      -- GetAccessTokenBySA fails, should fallback to GetAccessTokenByWI
+      assert.same(gcpToken.token, "test_wi_fallback")
+      assert.same(gcpToken.authMethod, "WI")
+      assert.is_number(gcpToken.expireTime)
+      assert.is_false(gcpToken:needsRefresh())
+    end)
+  end)
+
+  it("should fallback to SA when WI fails in legacy mode", function()
+    local wi_failure_responses = {
+      ["https://www.googleapis.com/oauth2/v4/token"] = {
+        status = 200,
+        body = [[{"access_token": "test_sa_fallback", "expires_in": 3600}]],
+      },
+      ["http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"] = function()
+        return nil, "connection refused"
+      end
+    }
+
+    with_http_mock(wi_failure_responses, function(temp_access_token)
+      local gcpToken = temp_access_token(nil, { auth_method_order = "legacy" })
+      -- GetAccessTokenByWI fails, should fallback to GetAccessTokenBySA
+      assert.same(gcpToken.token, "test_sa_fallback")
+      assert.same(gcpToken.authMethod, "SA")
+      assert.is_number(gcpToken.expireTime)
+      assert.is_false(gcpToken:needsRefresh())
+    end)
   end)
 
 end)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -216,7 +216,7 @@ describe("access token", function ()
     end)
   end)
 
-  it("can properly handle expire_in values less than expireWindow", function()
+  it("can properly handle expires_in values less than expireWindow", function()
     local sa_responses = {
       ["https://www.googleapis.com/oauth2/v4/token"] = {
         status = 200,

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -231,7 +231,7 @@ describe("access token", function ()
 
     with_http_mock(sa_responses, function(temp_access_token)
       local gcpToken = temp_access_token(nil, { auth_method_order = "adc" })
-      -- GetAccessTokenBySA fails, should fallback to GetAccessTokenByWI
+      -- Test that tokens with short expiration times (less than expireWindow) are handled correctly
       assert.same(gcpToken.token, "test_sa_token")
       assert.same(gcpToken.authMethod, "SA")
       assert.is_number(gcpToken.expireTime)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -216,4 +216,31 @@ describe("access token", function ()
     end)
   end)
 
+  it("can properly handle expire_in values less than expireWindow.", function()
+    local sa_responses = {
+      ["https://www.googleapis.com/oauth2/v4/token"] = {
+        status = 200,
+        -- expires_in 1s is less than the default expireWindow 15s
+        body = [[{"access_token": "test_sa_token", "expires_in": 1}]],
+      },
+      ["http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"] = {
+        status = 400,
+        body = [[{"error": "invalid_grant", "error_description": "Invalid JWT"}]],
+      }
+    }
+
+    with_http_mock(sa_responses, function(temp_access_token)
+      local gcpToken = temp_access_token(nil, { auth_method_order = "adc" })
+      -- GetAccessTokenBySA fails, should fallback to GetAccessTokenByWI
+      assert.same(gcpToken.token, "test_sa_token")
+      assert.same(gcpToken.authMethod, "SA")
+      assert.is_number(gcpToken.expireTime)
+      assert.is_false(gcpToken:needsRefresh())
+
+      ngx.sleep(2)
+
+      assert.is_true(gcpToken:needsRefresh())
+    end)
+  end)
+
 end)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -37,15 +37,12 @@ describe("access token", function ()
     package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
     local temp_access_token = require "resty.gcp.request.credentials.accesstoken"
     
-    local success, result = pcall(test_function, temp_access_token)
+    -- Execute test function (let test failures propagate naturally)
+    test_function(temp_access_token)
     
+    -- Restore original state
     package.loaded["resty.luasocket.http"] = original_http
     package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
-    
-    if not success then
-      error(result)
-    end
-    return result
   end
 
   -- Default successful responses

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -216,7 +216,7 @@ describe("access token", function ()
     end)
   end)
 
-  it("can properly handle expire_in values less than expireWindow.", function()
+  it("can properly handle expire_in values less than expireWindow", function()
     local sa_responses = {
       ["https://www.googleapis.com/oauth2/v4/token"] = {
         status = 200,

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -110,8 +110,9 @@ local function GetAccessTokenByWI()
             },
         }
     )
-    if not res then
-        ngx.log(ngx.DEBUG, "[accesstoken] failed to Access Token ", tostring(err))
+
+    if not res or not res.status or (res.status >= 400) then
+        ngx.log(ngx.ERR , "[accesstoken] failed to Access Token ", tostring(err))
         return
     end
     client:close()
@@ -150,9 +151,9 @@ function AccessToken:new(gcpServiceAccount, opts)
     -- and add the ADC (Application Default Credentials) option.
     if auth_method_order == "legacy" then
       -- First try via Workload Identity and then via Service Account
-      accessToken, authMethod = GetAccessTokenByWI()
+      accessToken, authMethod = safe_call(GetAccessTokenByWI)
       if not accessToken then
-        accessToken, authMethod = GetAccessTokenBySA(gcpServiceAccount)
+        accessToken, authMethod = safe_call(GetAccessTokenBySA, gcpServiceAccount)
       end
 
     -- This simulates the official behavior of Application Default Credentials
@@ -160,9 +161,9 @@ function AccessToken:new(gcpServiceAccount, opts)
     -- for more details.
     -- The implementation is not exactly the same but a similar order of precedence is followed.
     elseif auth_method_order == "adc" then
-      accessToken, authMethod = GetAccessTokenBySA(gcpServiceAccount)
+      accessToken, authMethod = safe_call(GetAccessTokenBySA, gcpServiceAccount)
       if not accessToken then
-          accessToken, authMethod = GetAccessTokenByWI()
+          accessToken, authMethod = safe_call(GetAccessTokenByWI)
       end
 
     else

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -112,7 +112,7 @@ local function GetAccessTokenByWI()
     )
 
     if not res or not res.status or (res.status >= 400) then
-        ngx.log(ngx.ERR , "[accesstoken] failed to Access Token ", tostring(err))
+        ngx.log(ngx.ERR, "[accesstoken] failed to Access Token ", tostring(err))
         return
     end
     client:close()

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -133,7 +133,7 @@ function AccessToken.__index(self, key)
         end
         return rawget(self, "_token")
     end
-    
+
     return AccessToken[key]
 end
 
@@ -142,6 +142,8 @@ function AccessToken:new(gcpServiceAccount, opts)
     opts = opts or {}
 
     setmetatable(self, AccessToken)
+
+    self.expireWindow = opts.expireWindow or EXPIRY_WINDOW
 
     local auth_method_order = opts.auth_method_order or "legacy"
     gcpServiceAccount = gcpServiceAccount or os.getenv("GCP_SERVICE_ACCOUNT")
@@ -172,7 +174,13 @@ function AccessToken:new(gcpServiceAccount, opts)
 
     if (accessToken) then
         self._token = accessToken.access_token
-        self.expireTime = ngx.now() + accessToken.expires_in
+
+        if accessToken.expires_in > self.expireWindow then
+            self.expireTime = ngx.now() + accessToken.expires_in - self.expireWindow
+        else
+            self.expireTime = ngx.now() + accessToken.expires_in
+        end
+
         self.authMethod = authMethod
         self.gcpServiceAccount = gcpServiceAccount
     else
@@ -181,12 +189,11 @@ function AccessToken:new(gcpServiceAccount, opts)
         return nil
     end
 
-    self.expireWindow = opts.expireWindow or EXPIRY_WINDOW
     return self
 end
 
 function AccessToken:needsRefresh()
-    return self.expireTime < (ngx.now() + self.expireWindow)
+    return self.expireTime < ngx.now()
 end
 
 function AccessToken:refresh()
@@ -211,15 +218,19 @@ function AccessToken:refresh()
             elseif (self.authMethod == "WI") then
                 accessToken, err = safe_call(GetAccessTokenByWI)
             end
-            
+
             if (accessToken) then
                 self._token = accessToken.access_token
-                self.expireTime = ngx.now() + accessToken.expires_in
+                if accessToken.expires_in > self.expireWindow then
+                  self.expireTime = ngx.now() + accessToken.expires_in - self.expireWindow
+                else
+                  self.expireTime = ngx.now() + accessToken.expires_in
+                end
             end
 
             self._semaphore = nil
             sema:post(math.abs(sema:count()) + 1)
-            
+
             if not accessToken then
                 ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(err))
                 return nil, "failed to get new access token: " .. tostring(err)


### PR DESCRIPTION
### Summary

1. Make `AccessToken:new` handle errors correctly and make `GetAccessTokenByWI`  handle token acquisition fail correctly.
2. fixed the infinite loop issue if GCP service returned expire TTL is less than self.expireWindow in the `:refresh()` function

### Issue reference

 [KAG-7777](https://konghq.atlassian.net/browse/KAG-7777)

[KAG-7777]: https://konghq.atlassian.net/browse/KAG-7777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ