### PR TITLE
fix(log): correct typos in access token log messages

### DIFF
--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -79,7 +79,7 @@ local function GetAccessTokenByJwt(jwtToken)
 end
 
 local function GetAccessTokenBySA(serviceAccount)
-    ngx.log(ngx.DEBUG, "[accesstoken] Using Envrionment Service Account to get Access Token")
+    ngx.log(ngx.DEBUG, "[accesstoken] Using Environment Service Account to get Access Token")
 
     if not serviceAccount then
         -- Note: nginx workers do not have access to env vars. initialize in init phase
@@ -112,7 +112,7 @@ local function GetAccessTokenByWI()
     )
 
     if not res or not res.status or (res.status >= 400) then
-        ngx.log(ngx.ERR, "[accesstoken] failed to Access Token ", tostring(err))
+        ngx.log(ngx.ERR, "[accesstoken] failed to get Access Token ", tostring(err))
         return
     end
     client:close()


### PR DESCRIPTION
This PR fixes several minor typos and improves consistency in the
access token–related log messages.

### Changes
- Fixed "Envrionment" → "Environment" in the Service Account log.
- Updated "failed to Access Token" to "failed to get Access Token" for clarity.

### Notes
- These changes do not affect functionality.
- Only log message strings were updated.