### PR TITLE
fix(access_token): optimize the refresh interface and the token acquisition interface

### DIFF
--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -116,7 +116,6 @@ describe("access token", function ()
       assert.is_false(wiToken:needsRefresh())
 
       wiToken.expireTime = ngx.now() - 100
-      wiToken.token = nil
       assert.is_true(wiToken:needsRefresh())
 
       local ok, token, expireTime = wiToken:refresh()
@@ -142,7 +141,6 @@ describe("access token", function ()
       assert.is_false(saToken:needsRefresh())
 
       saToken.expireTime = ngx.now() - 100
-      saToken.token = nil
       assert.is_true(saToken:needsRefresh())
 
       local ok, token, expireTime = saToken:refresh()

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -384,7 +384,6 @@ describe("access token", function ()
         gcpToken.expireTime = ngx.now() - 100
         assert.is_true(gcpToken:needsRefresh())
 
-        -- Access token property to trigger refresh
         local ok, token, expireTime = gcpToken:refresh()
         assert.is_true(ok)
         assert.same("test_refresh_token_2", token)

--- a/spec/03-credentials_spec.lua
+++ b/spec/03-credentials_spec.lua
@@ -32,14 +32,14 @@ describe("access token", function ()
   local function with_http_mock(mock_responses, test_function)
     local original_http = package.loaded["resty.luasocket.http"]
     package.loaded["resty.luasocket.http"] = create_http_mock(mock_responses)
-    
+
     -- Reload the access_token module to use the new HTTP mock
     package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
     local temp_access_token = require "resty.gcp.request.credentials.accesstoken"
-    
+
     -- Execute test function (let test failures propagate naturally)
     test_function(temp_access_token)
-    
+
     -- Restore original state
     package.loaded["resty.luasocket.http"] = original_http
     package.loaded["resty.gcp.request.credentials.accesstoken"] = nil
@@ -56,7 +56,7 @@ describe("access token", function ()
       body = [[{"access_token": "test_wi", "expires_in": 3600}]],
     }
   }
-  
+
   setup(function()
     package.loaded["resty.luasocket.http"] = create_http_mock(default_responses)
   end)
@@ -85,21 +85,21 @@ describe("access token", function ()
 
   it("should create an access token with default auth method", function()
     local gcpToken = access_token()
-    assert.same(gcpToken.token, "test_wi")
+    assert.same("test_wi", gcpToken.token)
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
 
   it("should create an access token with legacy auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "legacy" })
-    assert.same(gcpToken.token, "test_wi")    
+    assert.same("test_wi", gcpToken.token)
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
 
   it("should create an access token with adc auth method order", function()
     local gcpToken = access_token(nil, { auth_method_order = "adc" })
-    assert.same(gcpToken.token, "test_jwt")
+    assert.same("test_jwt", gcpToken.token)
     assert.is_number(gcpToken.expireTime)
     assert.is_boolean(gcpToken:needsRefresh())
   end)
@@ -116,8 +116,13 @@ describe("access token", function ()
       assert.is_false(wiToken:needsRefresh())
 
       wiToken.expireTime = ngx.now() - 100
+      wiToken.token = nil
       assert.is_true(wiToken:needsRefresh())
 
+      local ok, token, expireTime = wiToken:refresh()
+      assert.is_true(ok)
+      assert.same("string", type(token))
+      assert.same("number", type(expireTime))
       assert.same("string", type(wiToken.token))
       assert.same("number", type(wiToken.expireTime))
       assert.same("WI", wiToken.authMethod)
@@ -137,9 +142,13 @@ describe("access token", function ()
       assert.is_false(saToken:needsRefresh())
 
       saToken.expireTime = ngx.now() - 100
+      saToken.token = nil
       assert.is_true(saToken:needsRefresh())
 
-
+      local ok, token, expireTime = saToken:refresh()
+      assert.is_true(ok)
+      assert.same("string", type(token))
+      assert.same("number", type(expireTime))
       assert.same("string", type(saToken.token))
       assert.same("number", type(saToken.expireTime))
       assert.same("SA", saToken.authMethod)
@@ -148,28 +157,32 @@ describe("access token", function ()
 
   it("should handle AccessToken refresh concurrency simulation", function()
     local gcpToken = access_token()
-    
+
     gcpToken.expireTime = ngx.now() - 100
-    
+
     local tokens = {}
+    local expireTimes = {}
     local errors = {}
-    
+
     for i = 1, 3 do
-        local token = gcpToken.token
-        if token then
-            table.insert(tokens, token)
+        local ok, token_or_err, expireTime = gcpToken:get()
+        if ok then
+            table.insert(tokens, token_or_err)
+            table.insert(expireTimes, expireTime)
         else
-            table.insert(errors, "failed to get token")
+            table.insert(errors, token_or_err)
         end
     end
-    
+
     assert.equals(3, #tokens)
+    assert.equals(3, #expireTimes)
     assert.equals(0, #errors)
-    
+
     for i = 1, #tokens do
         assert.equals(tokens[1], tokens[i])
+        assert.same("number", type(expireTimes[i]))
     end
-    
+
     assert.is_false(gcpToken:needsRefresh())
   end)
 
@@ -188,8 +201,8 @@ describe("access token", function ()
     with_http_mock(sa_failure_responses, function(temp_access_token)
       local gcpToken = temp_access_token(nil, { auth_method_order = "adc" })
       -- GetAccessTokenBySA fails, should fallback to GetAccessTokenByWI
-      assert.same(gcpToken.token, "test_wi_fallback")
-      assert.same(gcpToken.authMethod, "WI")
+      assert.same("test_wi_fallback", gcpToken.token)
+      assert.same("WI", gcpToken.authMethod)
       assert.is_number(gcpToken.expireTime)
       assert.is_false(gcpToken:needsRefresh())
     end)
@@ -209,8 +222,8 @@ describe("access token", function ()
     with_http_mock(wi_failure_responses, function(temp_access_token)
       local gcpToken = temp_access_token(nil, { auth_method_order = "legacy" })
       -- GetAccessTokenByWI fails, should fallback to GetAccessTokenBySA
-      assert.same(gcpToken.token, "test_sa_fallback")
-      assert.same(gcpToken.authMethod, "SA")
+      assert.same("test_sa_fallback", gcpToken.token)
+      assert.same("SA", gcpToken.authMethod)
       assert.is_number(gcpToken.expireTime)
       assert.is_false(gcpToken:needsRefresh())
     end)
@@ -232,8 +245,8 @@ describe("access token", function ()
     with_http_mock(sa_responses, function(temp_access_token)
       local gcpToken = temp_access_token(nil, { auth_method_order = "adc" })
       -- Test that tokens with short expiration times (less than expireWindow) are handled correctly
-      assert.same(gcpToken.token, "test_sa_token")
-      assert.same(gcpToken.authMethod, "SA")
+      assert.same("test_sa_token", gcpToken.token)
+      assert.same("SA", gcpToken.authMethod)
       assert.is_number(gcpToken.expireTime)
       assert.is_false(gcpToken:needsRefresh())
 
@@ -264,9 +277,9 @@ describe("access token", function ()
           oauth_token_url = custom_oauth_url
         })
 
-        assert.same(gcpToken.token, "test_custom_oauth_token")
-        assert.same(gcpToken.authMethod, "SA")
-        assert.same(gcpToken.oauthTokenUrl, custom_oauth_url)
+        assert.same("test_custom_oauth_token", gcpToken.token)
+        assert.same("SA", gcpToken.authMethod)
+        assert.same(custom_oauth_url, gcpToken.oauthTokenUrl)
         assert.is_number(gcpToken.expireTime)
         assert.is_false(gcpToken:needsRefresh())
       end)
@@ -291,9 +304,9 @@ describe("access token", function ()
           metadata_url = custom_metadata_url
         })
 
-        assert.same(gcpToken.token, "test_custom_wi_token")
-        assert.same(gcpToken.authMethod, "WI")
-        assert.same(gcpToken.metadataUrl, custom_metadata_url)
+        assert.same("test_custom_wi_token", gcpToken.token)
+        assert.same("WI", gcpToken.authMethod)
+        assert.same(custom_metadata_url, gcpToken.metadataUrl)
         assert.is_number(gcpToken.expireTime)
         assert.is_false(gcpToken:needsRefresh())
       end)
@@ -321,10 +334,10 @@ describe("access token", function ()
           metadata_url = custom_metadata_url
         })
 
-        assert.same(gcpTokenSA.token, "test_custom_both_token")
-        assert.same(gcpTokenSA.authMethod, "SA")
-        assert.same(gcpTokenSA.oauthTokenUrl, custom_oauth_url)
-        assert.same(gcpTokenSA.metadataUrl, custom_metadata_url)
+        assert.same("test_custom_both_token", gcpTokenSA.token)
+        assert.same("SA", gcpTokenSA.authMethod)
+        assert.same(custom_oauth_url, gcpTokenSA.oauthTokenUrl)
+        assert.same(custom_metadata_url, gcpTokenSA.metadataUrl)
       end)
 
       with_http_mock(custom_responses, function(temp_access_token)
@@ -335,10 +348,10 @@ describe("access token", function ()
           metadata_url = custom_metadata_url
         })
 
-        assert.same(gcpTokenWI.token, "test_custom_wi_both_token")
-        assert.same(gcpTokenWI.authMethod, "WI")
-        assert.same(gcpTokenWI.oauthTokenUrl, custom_oauth_url)
-        assert.same(gcpTokenWI.metadataUrl, custom_metadata_url)
+        assert.same("test_custom_wi_both_token", gcpTokenWI.token)
+        assert.same("WI", gcpTokenWI.authMethod)
+        assert.same(custom_oauth_url, gcpTokenWI.oauthTokenUrl)
+        assert.same(custom_metadata_url, gcpTokenWI.metadataUrl)
       end)
     end)
 
@@ -365,8 +378,8 @@ describe("access token", function ()
         })
 
         -- First token
-        assert.same(gcpToken.token, "test_refresh_token_1")
-        assert.same(gcpToken.authMethod, "SA")
+        assert.same("test_refresh_token_1", gcpToken.token)
+        assert.same("SA", gcpToken.authMethod)
         assert.equals(1, refresh_counter)
 
         -- Force refresh
@@ -374,8 +387,10 @@ describe("access token", function ()
         assert.is_true(gcpToken:needsRefresh())
 
         -- Access token property to trigger refresh
-        local refreshed_token = gcpToken.token
-        assert.same(refreshed_token, "test_refresh_token_2")
+        local ok, token, expireTime = gcpToken:refresh()
+        assert.is_true(ok)
+        assert.same("test_refresh_token_2", token)
+        assert.same("number", type(expireTime))
         assert.equals(2, refresh_counter)
         assert.is_false(gcpToken:needsRefresh())
       end)
@@ -405,8 +420,8 @@ describe("access token", function ()
         })
 
         -- First token
-        assert.same(gcpToken.token, "test_wi_refresh_token_1")
-        assert.same(gcpToken.authMethod, "WI")
+        assert.same("test_wi_refresh_token_1", gcpToken.token)
+        assert.same("WI", gcpToken.authMethod)
         assert.equals(1, refresh_counter)
 
         -- Force refresh
@@ -414,8 +429,10 @@ describe("access token", function ()
         assert.is_true(gcpToken:needsRefresh())
 
         -- Access token property to trigger refresh
-        local refreshed_token = gcpToken.token
-        assert.same(refreshed_token, "test_wi_refresh_token_2")
+        local ok, token, expireTime = gcpToken:refresh()
+        assert.is_true(ok)
+        assert.same("test_wi_refresh_token_2", token)
+        assert.same("number", type(expireTime))
         assert.equals(2, refresh_counter)
         assert.is_false(gcpToken:needsRefresh())
       end)
@@ -425,9 +442,9 @@ describe("access token", function ()
       -- Test that when no custom URLs are provided, default URLs are used
       local gcpToken = access_token(nil, { auth_method_order = "legacy" })
 
-      assert.same(gcpToken.token, "test_wi")
-      assert.same(gcpToken.oauthTokenUrl, "https://www.googleapis.com/oauth2/v4/token")
-      assert.same(gcpToken.metadataUrl, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+      assert.same("test_wi", gcpToken.token)
+      assert.same("https://www.googleapis.com/oauth2/v4/token", gcpToken.oauthTokenUrl)
+      assert.same("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", gcpToken.metadataUrl)
       assert.is_number(gcpToken.expireTime)
       assert.is_false(gcpToken:needsRefresh())
     end)
@@ -439,9 +456,9 @@ describe("access token", function ()
         metadata_url = nil      -- explicitly set to nil
       })
 
-      assert.same(gcpToken.token, "test_wi")
-      assert.same(gcpToken.oauthTokenUrl, "https://www.googleapis.com/oauth2/v4/token")
-      assert.same(gcpToken.metadataUrl, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+      assert.same("test_wi", gcpToken.token)
+      assert.same("https://www.googleapis.com/oauth2/v4/token", gcpToken.oauthTokenUrl)
+      assert.same("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", gcpToken.metadataUrl)
     end)
 
     it("should use custom oauth_token_url in JWT aud field", function()
@@ -477,7 +494,7 @@ describe("access token", function ()
         oauth_token_url = custom_oauth_url
       })
 
-      assert.same(gcpToken.token, "test_custom_aud_token")
+      assert.same("test_custom_aud_token", gcpToken.token)
       assert.is_not_nil(captured_request_body)
 
       -- Verify the JWT contains the custom URL (it's in the assertion field of the request)

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -125,21 +125,7 @@ local function GetAccessTokenByWI(metadata_url)
 end
 
 local AccessToken = {}
-
-function AccessToken.__index(self, key)
-    if key == "token" then
-        if self:needsRefresh() then
-            local ok, err = self:refresh()
-            if not ok then
-                ngx.log(ngx.ERR, "[accesstoken] auto refresh failed: ", tostring(err))
-                return nil
-            end
-        end
-        return rawget(self, "_token")
-    end
-
-    return AccessToken[key]
-end
+AccessToken.__index = AccessToken
 
 function AccessToken:new(gcpServiceAccount, opts)
     local self = {}
@@ -179,7 +165,7 @@ function AccessToken:new(gcpServiceAccount, opts)
     end
 
     if (accessToken) then
-        self._token = accessToken.access_token
+        self.token = accessToken.access_token
         local new_token_expires_in = tonumber(accessToken.expires_in)
         if new_token_expires_in > self.expireWindow then
             self.expireTime = ngx.now() + new_token_expires_in - self.expireWindow
@@ -202,50 +188,65 @@ function AccessToken:needsRefresh()
     return self.expireTime < ngx.now()
 end
 
+--- Forces refresh by requesting a new access token regardless of expiry state.
+--- @return boolean ok true on success, false on failure
+--- @return string|nil token_or_err the access token on success, or error message on failure
+--- @return number|nil expireTime the token expiration time on success, or nil on failure
 function AccessToken:refresh()
+    local accessToken, err
+    if (self.authMethod == "SA") then
+        accessToken, err = safe_call(GetAccessTokenBySA, self.gcpServiceAccount, self.oauthTokenUrl)
+    elseif (self.authMethod == "WI") then
+        accessToken, err = safe_call(GetAccessTokenByWI, self.metadataUrl)
+    end
+
+    if (accessToken) then
+        self.token = accessToken.access_token
+        local new_token_expires_in = tonumber(accessToken.expires_in)
+        if new_token_expires_in > self.expireWindow then
+            self.expireTime = ngx.now() + new_token_expires_in - self.expireWindow
+        else
+            self.expireTime = ngx.now() + new_token_expires_in
+        end
+        return true, self.token, self.expireTime
+    end
+
+    return false, err, nil
+end
+
+--- Auto-refresh: only refreshes when the current token is expired (or within expiry window).
+--- @return boolean ok true on success, false on failure
+--- @return string|nil token_or_err the access token on success, or error message on failure
+--- @return number|nil expireTime the token expiration time on success, or nil on failure
+function AccessToken:get()
     while self:needsRefresh() do
         if self._semaphore then
             local ok, err = self._semaphore:wait(SEMAPHORE_TIMEOUT)
             if not ok then
                 ngx.log(ngx.ERR, "[accesstoken] semaphore wait failed: ", tostring(err))
-                return nil, "semaphore wait failed: " .. tostring(err)
+                return false, "semaphore wait failed: " .. tostring(err), nil
             end
         else
             local sema, err = semaphore:new()
             if not sema then
                 ngx.log(ngx.ERR, "[accesstoken] create semaphore failed: ", tostring(err))
-                return nil, "create semaphore failed: " .. tostring(err)
+                return false, "create semaphore failed: " .. tostring(err)
             end
             self._semaphore = sema
 
-            local accessToken, err
-            if (self.authMethod == "SA") then
-                accessToken, err = safe_call(GetAccessTokenBySA, self.gcpServiceAccount, self.oauthTokenUrl)
-            elseif (self.authMethod == "WI") then
-                accessToken, err = safe_call(GetAccessTokenByWI, self.metadataUrl)
-            end
-
-            if (accessToken) then
-                self._token = accessToken.access_token
-                local new_token_expires_in = tonumber(accessToken.expires_in)
-                if new_token_expires_in > self.expireWindow then
-                  self.expireTime = ngx.now() + new_token_expires_in - self.expireWindow
-                else
-                  self.expireTime = ngx.now() + new_token_expires_in
-                end
-            end
+            local ok, token_or_err = self:refresh()
 
             self._semaphore = nil
             sema:post(math.abs(sema:count()) + 1)
 
-            if not accessToken then
-                ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(err))
-                return nil, "failed to get new access token: " .. tostring(err)
+            if not ok then
+                ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(token_or_err))
+                return false, "failed to get new access token: " .. tostring(token_or_err)
             end
         end
     end
 
-    return true
+    return true, self.token, self.expireTime
 end
 
 return setmetatable(

--- a/src/resty/gcp/request/credentials/accesstoken.lua
+++ b/src/resty/gcp/request/credentials/accesstoken.lua
@@ -8,31 +8,17 @@ local EXPIRY_WINDOW = 15 -- expiry window in seconds
 local DEFAULT_OAUTH_TOKEN_URL = "https://www.googleapis.com/oauth2/v4/token"
 local DEFAULT_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
 
--- Executes a xpcall but returns hard-errors as Lua 'nil+err' result.
--- Handles max of 10 return values.
--- @param f function to execute
--- @param ... parameters to pass to the function
-local function safe_call(f, ...)
-  local ok, result, err, r3, r4, r5, r6, r7, r8, r9, r10 = xpcall(f, debug.traceback, ...)
-  if ok then
-    return result, err, r3, r4, r5, r6, r7, r8, r9, r10
-  end
-  return nil, result
-end
-
 local function GetJwtToken(serviceAccount, oauth_token_url)
     oauth_token_url = oauth_token_url or DEFAULT_OAUTH_TOKEN_URL
     local saDecode, err = cjson.decode(serviceAccount)
     if type(saDecode) ~= "table" then
         ngx.log(ngx.ERR, "[accesstoken] Invalid GCP_SERVICE_ACCOUNT, expect JSON: ", tostring(err))
-        error("Invalid format for GCP Service Account")
-        return
+        return nil, "Invalid format for GCP Service Account"
     end
     local timeNow = os.time()
     if (not (saDecode.client_email and saDecode.private_key and saDecode.private_key_id)) then
         ngx.log(ngx.ERR, "[accesstoken] Invalid GCP_SERVICE_ACCOUNT, missing required field")
-        error("Invalid GCP Service Account")
-        return
+        return nil, "Invalid GCP Service Account"
     end
     local payload = {
         iss = saDecode.client_email,
@@ -43,7 +29,7 @@ local function GetJwtToken(serviceAccount, oauth_token_url)
         scope = "https://www.googleapis.com/auth/cloud-platform"
     }
     local payloadJson = cjson.encode(payload)
-    local jwt_token =
+    local jwt_token, err =
         jwt:sign(
         saDecode.private_key,
         {
@@ -51,6 +37,10 @@ local function GetJwtToken(serviceAccount, oauth_token_url)
             payload = payloadJson
         }
     )
+    if not jwt_token then
+        ngx.log(ngx.ERR, "[accesstoken] Failed to sign JWT: ", tostring(err))
+        return nil, err
+    end
     return jwt_token
 end
 
@@ -72,12 +62,15 @@ local function GetAccessTokenByJwt(jwtToken, oauth_token_url)
     )
     if not res then
         ngx.log(ngx.ERR, "[accesstoken] Unable to get access token")
-        error(err)
-        return
+        return nil, err
     end
 
     client:close()
     local accessToken = cjson.decode(res.body)
+    if accessToken.error then
+        ngx.log(ngx.ERR, "[accesstoken] Unable to get access token: ", accessToken.error_description)
+        return nil, accessToken.error_description
+    end
     return accessToken
 end
 
@@ -89,14 +82,15 @@ local function GetAccessTokenBySA(serviceAccount, oauth_token_url)
         -- Note: nginx workers do not have access to env vars. initialize in init phase
         -- or by the 'config' module.
         ngx.log(ngx.ERR, "[accesstoken] Couldn't find GCP_SERVICE_ACCOUNT env variable")
-        error("Couldn't find GCP_SERVICE_ACCOUNT env variable")
-        return
+        return nil, "Couldn't find GCP_SERVICE_ACCOUNT env variable"
     end
-    local jwtToken = GetJwtToken(serviceAccount, oauth_token_url)
-    local res = assert(GetAccessTokenByJwt(jwtToken, oauth_token_url))
-    if res.error then
-        ngx.log(ngx.ERR, "[accesstoken] Unable to get access token: ", res.error_description)
-        return
+    local jwtToken, err = GetJwtToken(serviceAccount, oauth_token_url)
+    if not jwtToken then
+        return nil, err
+    end
+    local res, err = GetAccessTokenByJwt(jwtToken, oauth_token_url)
+    if not res then
+        return nil, err
     end
     return res, "SA"
 end
@@ -117,16 +111,37 @@ local function GetAccessTokenByWI(metadata_url)
 
     if not res or not res.status or (res.status >= 400) then
         ngx.log(ngx.ERR, "[accesstoken] failed to get Access Token ", tostring(err))
-        return
+        return nil, err or "failed to get Access Token"
     end
     client:close()
     local accessToken = cjson.decode(res.body)
     return accessToken, "WI"
 end
 
+--- AccessToken class for managing GCP access tokens.
+-- @classmod AccessToken
+-- @field token string the current access token
+-- @field expireTime number the token expiration time
+-- @field authMethod string the authentication method used ("SA" or "WI")
+-- @field gcpServiceAccount string|nil the GCP service account JSON
+-- @field expireWindow number the expiry window in seconds
+-- @field oauthTokenUrl string the OAuth token URL
+-- @field metadataUrl string the metadata URL for Workload Identity
 local AccessToken = {}
+
 AccessToken.__index = AccessToken
 
+--- Create a new AccessToken instance and acquire an initial token.
+-- @tparam[opt] string gcpServiceAccount service account JSON string;
+--   if nil, falls back to the `GCP_SERVICE_ACCOUNT` environment variable
+-- @tparam[opt] table opts configuration options
+-- @tparam[opt=15] number opts.expireWindow seconds before expiry to trigger refresh
+-- @tparam[opt] string opts.oauth_token_url OAuth token endpoint URL
+-- @tparam[opt] string opts.metadata_url GCE metadata endpoint URL
+-- @tparam[opt="legacy"] string opts.auth_method_order authentication order:
+--   `"legacy"` tries WI then SA; `"adc"` tries SA then WI
+-- @treturn AccessToken a new AccessToken instance
+-- @return nil, string on failure: nil and an error message
 function AccessToken:new(gcpServiceAccount, opts)
     local self = {}
     opts = opts or {}
@@ -145,9 +160,9 @@ function AccessToken:new(gcpServiceAccount, opts)
     -- and add the ADC (Application Default Credentials) option.
     if auth_method_order == "legacy" then
       -- First try via Workload Identity and then via Service Account
-      accessToken, authMethod = safe_call(GetAccessTokenByWI, self.metadataUrl)
+      accessToken, authMethod = GetAccessTokenByWI(self.metadataUrl)
       if not accessToken then
-        accessToken, authMethod = safe_call(GetAccessTokenBySA, gcpServiceAccount, self.oauthTokenUrl)
+        accessToken, authMethod = GetAccessTokenBySA(gcpServiceAccount, self.oauthTokenUrl)
       end
 
     -- This simulates the official behavior of Application Default Credentials
@@ -155,9 +170,9 @@ function AccessToken:new(gcpServiceAccount, opts)
     -- for more details.
     -- The implementation is not exactly the same but a similar order of precedence is followed.
     elseif auth_method_order == "adc" then
-      accessToken, authMethod = safe_call(GetAccessTokenBySA, gcpServiceAccount, self.oauthTokenUrl)
+      accessToken, authMethod = GetAccessTokenBySA(gcpServiceAccount, self.oauthTokenUrl)
       if not accessToken then
-          accessToken, authMethod = safe_call(GetAccessTokenByWI, self.metadataUrl)
+          accessToken, authMethod = GetAccessTokenByWI(self.metadataUrl)
       end
 
     else
@@ -177,8 +192,7 @@ function AccessToken:new(gcpServiceAccount, opts)
         self.gcpServiceAccount = gcpServiceAccount
     else
         ngx.log(ngx.ERR, "[accesstoken] Unable to get accesstoken")
-        error("Failed to authenticate")
-        return nil
+        return nil, "Failed to authenticate"
     end
 
     return self
@@ -188,16 +202,16 @@ function AccessToken:needsRefresh()
     return self.expireTime < ngx.now()
 end
 
---- Forces refresh by requesting a new access token regardless of expiry state.
---- @return boolean ok true on success, false on failure
---- @return string|nil token_or_err the access token on success, or error message on failure
---- @return number|nil expireTime the token expiration time on success, or nil on failure
+--- Force refresh by requesting a new access token regardless of expiry state.
+-- @treturn boolean true on success, false on failure
+-- @treturn string the access token on success, or error message on failure
+-- @treturn number the token expiration timestamp on success, or nil on failure
 function AccessToken:refresh()
     local accessToken, err
     if (self.authMethod == "SA") then
-        accessToken, err = safe_call(GetAccessTokenBySA, self.gcpServiceAccount, self.oauthTokenUrl)
+        accessToken, err = GetAccessTokenBySA(self.gcpServiceAccount, self.oauthTokenUrl)
     elseif (self.authMethod == "WI") then
-        accessToken, err = safe_call(GetAccessTokenByWI, self.metadataUrl)
+        accessToken, err = GetAccessTokenByWI(self.metadataUrl)
     end
 
     if (accessToken) then
@@ -214,10 +228,10 @@ function AccessToken:refresh()
     return false, err, nil
 end
 
---- Auto-refresh: only refreshes when the current token is expired (or within expiry window).
---- @return boolean ok true on success, false on failure
---- @return string|nil token_or_err the access token on success, or error message on failure
---- @return number|nil expireTime the token expiration time on success, or nil on failure
+--- Get a valid access token, automatically refreshing when expired.
+-- @treturn boolean true on success, false on failure
+-- @treturn string the access token on success, or error message on failure
+-- @treturn number the token expiration timestamp on success, or nil on failure
 function AccessToken:get()
     while self:needsRefresh() do
         if self._semaphore then
@@ -230,18 +244,18 @@ function AccessToken:get()
             local sema, err = semaphore:new()
             if not sema then
                 ngx.log(ngx.ERR, "[accesstoken] create semaphore failed: ", tostring(err))
-                return false, "create semaphore failed: " .. tostring(err)
+                return false, "create semaphore failed: " .. tostring(err), nil
             end
             self._semaphore = sema
 
-            local ok, token_or_err = self:refresh()
+            local ok, token_or_err, _ = self:refresh()
 
             self._semaphore = nil
             sema:post(math.abs(sema:count()) + 1)
 
             if not ok then
                 ngx.log(ngx.ERR, "[accesstoken] failed to get new access token: ", tostring(token_or_err))
-                return false, "failed to get new access token: " .. tostring(token_or_err)
+                return false, "failed to get new access token: " .. tostring(token_or_err), nil
             end
         end
     end


### PR DESCRIPTION
### Summary

Unbind the automatic refresh and `.token`, and use `get()` for automatic refreshing and obtaining the token. Restore the `refresh()` to force refresh token.

### Issue reference
[FTI-6912](https://konghq.atlassian.net/browse/FTI-6912)

[FTI-6912]: https://konghq.atlassian.net/browse/FTI-6912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ