### PR TITLE
chore(ci): pin lua-resty-jwt version to 0.2.3 to fix ci error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         make
         make install
         export PATH=/usr/local/bin:$PATH
-        luarocks install lua-resty-jwt
+        luarocks install lua-resty-jwt 0.2.3
         luarocks install lua-resty-aws
     - name: Cache
       uses: actions/cache@v4


### PR DESCRIPTION
### Summary
pin lua-resty-jwt version to 0.2.3

### Issue reference
[FTI-6912](https://konghq.atlassian.net/browse/FTI-6912)

[FTI-6912]: https://konghq.atlassian.net/browse/FTI-6912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ