### PR TITLE
chore(ci): bump actions to node 24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     # Optional step to run on only changed files
     - name: Get changed files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,19 +24,19 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Optional step to run on only changed files
     - name: Get changed files
       id: changed-files
-      uses: kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+      uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311 # main
       with:
         files: |
           **.lua
 
     - name: Lua Check
       if: steps.changed-files.outputs.any_changed == 'true'
-      uses: Kong/public-shared-actions/code-check-actions/lua-lint@ac8939f0382827fbb43ce4e0028066a5ea4db01d # 4.1.2
+      uses: Kong/public-shared-actions/code-check-actions/lua-lint@916a6f6221b7eab6f5ae53d061274d588c965ae6 # 5.0.2
       with:
         additional_args: '--no-default-config --config .luacheckrc'
         files: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,7 +23,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Pin Semgrep Python constraints
         run: echo 'setuptools<81' > "$RUNNER_TEMP/semgrep-constraints.txt"
       - uses: Kong/public-shared-actions/security-actions/semgrep@a92df3beb1e69e27d86be56346488f15fecaf0de # 5.0.2

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -24,4 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: Kong/public-shared-actions/security-actions/semgrep@1c412fcf497b6b8ae6cc3313389aa8756de68eac # 5.0.1
+      - name: Pin Semgrep Python constraints
+        run: echo 'setuptools<81' > "$RUNNER_TEMP/semgrep-constraints.txt"
+      - uses: Kong/public-shared-actions/security-actions/semgrep@a92df3beb1e69e27d86be56346488f15fecaf0de # 5.0.2
+        env:
+          PIP_CONSTRAINT: ${{ runner.temp }}/semgrep-constraints.txt

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -23,5 +23,5 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: Kong/public-shared-actions/security-actions/semgrep@ac8939f0382827fbb43ce4e0028066a5ea4db01d # 4.1.2
+      - uses: actions/checkout@v5
+      - uses: Kong/public-shared-actions/security-actions/semgrep@1c412fcf497b6b8ae6cc3313389aa8756de68eac # 5.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       options: --init
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Install deps
       run: |
         apt-get update
@@ -42,7 +42,7 @@ jobs:
         luarocks install lua-resty-jwt 0.2.3
         luarocks install lua-resty-aws
     - name: Cache
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
       with:
         path: |
           ~/.cache
@@ -52,7 +52,7 @@ jobs:
       run: |
         luarocks install busted
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Run tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,21 +8,24 @@ jobs:
 
     strategy:
       matrix:
-        openresty_version:
-          - 1.17.8.2
-          - 1.19.9.1
+        include:
+          - openresty_version: 1.17.8.2
+            openresty_image: openresty/openresty:1.17.8.2-5-focal
+          - openresty_version: 1.19.9.1
+            openresty_image: openresty/openresty:1.19.9.1-14-jammy
 
     runs-on: ubuntu-latest
     container:
-      image: openresty/openresty:${{ matrix.openresty_version }}-alpine-fat
+      image: ${{ matrix.openresty_image }}
       # --init runs tinit as PID 1 and prevents the 'WARNING: killing the child process' spam from the test suite
       options: --init
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Install deps
       run: |
-        apk add --no-cache wget tar make gcc musl-dev openssl-dev curl
+        apt-get update
+        apt-get install -y --no-install-recommends wget tar make gcc libc6-dev libssl-dev curl ca-certificates
         wget https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.gz && tar zxvf expat-2.7.0.tar.gz
         cd expat-2.7.0 && ./configure && make && make install
         wget https://luarocks.github.io/luarocks/releases/luarocks-3.12.2.tar.gz
@@ -35,7 +38,7 @@ jobs:
         luarocks install lua-resty-jwt 0.2.3
         luarocks install lua-resty-aws
     - name: Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache
@@ -45,7 +48,7 @@ jobs:
       run: |
         luarocks install busted
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Run tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
             openresty_image: openresty/openresty:1.17.8.2-5-focal
           - openresty_version: 1.19.9.1
             openresty_image: openresty/openresty:1.19.9.1-14-jammy
+          - openresty_version: 1.27.1.2
+            openresty_image: openresty/openresty:1.27.1.2-5-jammy
+          - openresty_version: 1.29.2.5
+            openresty_image: openresty/openresty:1.29.2.5-1-jammy
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow dependencies to Node.js 24-compatible versions.
- Bump actions/checkout to v5 and actions/cache to v5.
- Update Kong shared action pins for changed-files, semgrep, and lua-lint.

